### PR TITLE
Improve splash UI and add email-based password recovery

### DIFF
--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -104,6 +104,18 @@ abstract class AppLocalizations {
   /// **'Sanam Security'**
   String get app_title;
 
+  /// No description provided for @splash_tagline.
+  ///
+  /// In en, this message translates to:
+  /// **'A digital companion for security guards.'**
+  String get splash_tagline;
+
+  /// No description provided for @splash_loading.
+  ///
+  /// In en, this message translates to:
+  /// **'Preparing your workspace...'**
+  String get splash_loading;
+
   /// No description provided for @theme_light.
   ///
   /// In en, this message translates to:
@@ -140,6 +152,18 @@ abstract class AppLocalizations {
   /// **'English'**
   String get english;
 
+  /// No description provided for @language_settings_title.
+  ///
+  /// In en, this message translates to:
+  /// **'Language settings'**
+  String get language_settings_title;
+
+  /// No description provided for @language_settings_hint.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose the language you prefer to use in the app.'**
+  String get language_settings_hint;
+
   /// No description provided for @login.
   ///
   /// In en, this message translates to:
@@ -152,11 +176,29 @@ abstract class AppLocalizations {
   /// **'Username'**
   String get username;
 
+  /// No description provided for @email.
+  ///
+  /// In en, this message translates to:
+  /// **'Email'**
+  String get email;
+
   /// No description provided for @password.
   ///
   /// In en, this message translates to:
   /// **'Password'**
   String get password;
+
+  /// No description provided for @email_required.
+  ///
+  /// In en, this message translates to:
+  /// **'Please enter your email'**
+  String get email_required;
+
+  /// No description provided for @email_invalid.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter a valid email address'**
+  String get email_invalid;
 
   /// No description provided for @forgot_password.
   ///
@@ -164,11 +206,29 @@ abstract class AppLocalizations {
   /// **'Forgot password?'**
   String get forgot_password;
 
+  /// No description provided for @forgot_via_username.
+  ///
+  /// In en, this message translates to:
+  /// **'Use username'**
+  String get forgot_via_username;
+
+  /// No description provided for @forgot_via_email.
+  ///
+  /// In en, this message translates to:
+  /// **'Use email'**
+  String get forgot_via_email;
+
   /// No description provided for @send_code.
   ///
   /// In en, this message translates to:
-  /// **'Send code to email'**
+  /// **'Send reset code'**
   String get send_code;
+
+  /// No description provided for @email_sent_success.
+  ///
+  /// In en, this message translates to:
+  /// **"We've sent a reset link to your email."**
+  String get email_sent_success;
 
   /// No description provided for @reset_password.
   ///

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -12,6 +12,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get app_title => 'سنام الأمن';
 
   @override
+  String get splash_tagline => 'حل رقمي متكامل لحراس الأمن';
+
+  @override
+  String get splash_loading => 'جاري تهيئة التطبيق...';
+
+  @override
   String get theme_light => 'نهاري';
 
   @override
@@ -30,19 +36,43 @@ class AppLocalizationsAr extends AppLocalizations {
   String get english => 'الإنجليزية';
 
   @override
+  String get language_settings_title => 'إعدادات اللغة';
+
+  @override
+  String get language_settings_hint => 'اختر اللغة التي تود استخدام التطبيق بها.';
+
+  @override
   String get login => 'تسجيل الدخول';
 
   @override
   String get username => 'اسم المستخدم';
 
   @override
+  String get email => 'البريد الإلكتروني';
+
+  @override
   String get password => 'كلمة المرور';
+
+  @override
+  String get email_required => 'يرجى إدخال البريد الإلكتروني';
+
+  @override
+  String get email_invalid => 'صيغة البريد الإلكتروني غير صحيحة';
 
   @override
   String get forgot_password => 'نسيت كلمة المرور؟';
 
   @override
-  String get send_code => 'إرسال الرمز للبريد';
+  String get forgot_via_username => 'باستخدام اسم المستخدم';
+
+  @override
+  String get forgot_via_email => 'باستخدام البريد الإلكتروني';
+
+  @override
+  String get send_code => 'إرسال رمز الاستعادة';
+
+  @override
+  String get email_sent_success => 'تم إرسال رابط الاستعادة إلى بريدك';
 
   @override
   String get reset_password => 'استعادة كلمة المرور';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -12,6 +12,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get app_title => 'Sanam Security';
 
   @override
+  String get splash_tagline => 'A digital companion for security guards.';
+
+  @override
+  String get splash_loading => 'Preparing your workspace...';
+
+  @override
   String get theme_light => 'Light';
 
   @override
@@ -30,19 +36,43 @@ class AppLocalizationsEn extends AppLocalizations {
   String get english => 'English';
 
   @override
+  String get language_settings_title => 'Language settings';
+
+  @override
+  String get language_settings_hint => 'Choose the language you prefer to use in the app.';
+
+  @override
   String get login => 'Login';
 
   @override
   String get username => 'Username';
 
   @override
+  String get email => 'Email';
+
+  @override
   String get password => 'Password';
+
+  @override
+  String get email_required => 'Please enter your email';
+
+  @override
+  String get email_invalid => 'Enter a valid email address';
 
   @override
   String get forgot_password => 'Forgot password?';
 
   @override
-  String get send_code => 'Send code to email';
+  String get forgot_via_username => 'Use username';
+
+  @override
+  String get forgot_via_email => 'Use email';
+
+  @override
+  String get send_code => 'Send reset code';
+
+  @override
+  String get email_sent_success => "We've sent a reset link to your email.";
 
   @override
   String get reset_password => 'Reset password';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,7 +52,7 @@ class SanamApp extends StatelessWidget {
         GlobalCupertinoLocalizations.delegate,
       ],
 
-      home: const Shell(child: SplashScreen()),
+      home: const Shell(child: SplashScreen(), showAppBar: false),
 
       routes: {
         LoginScreen.route: (_) => const Shell(child: LoginScreen()),
@@ -67,7 +67,8 @@ class SanamApp extends StatelessWidget {
 /// شيل يضيف AppBar موحّد بأزرار (تبديل الثيم واللغة) لكل شاشة
 class Shell extends StatelessWidget {
   final Widget child;
-  const Shell({super.key, required this.child});
+  final bool showAppBar;
+  const Shell({super.key, required this.child, this.showAppBar = true});
   Future<void> _logout(BuildContext context) async {
     await ApiService.logout();
     Navigator.of(context).pushNamedAndRemoveUntil(
@@ -86,35 +87,37 @@ class Shell extends StatelessWidget {
       textDirection: settings.locale.languageCode == 'ar'
           ? TextDirection.rtl : TextDirection.ltr,
       child: Scaffold(
-        appBar: AppBar(
-          title: Text(t.app_title),
-          actions: [
+        appBar: showAppBar
+            ? AppBar(
+                title: Text(t.app_title),
+                actions: [
 
-            // تبديل الثيم
-            IconButton(
-              tooltip: t.toggle_theme,
-              onPressed: () => settings.toggleTheme(),
-              icon: Icon(isDark ? Icons.light_mode : Icons.dark_mode),
-            ),
-            // اختيار اللغة
-            PopupMenuButton<String>(
-              tooltip: t.language,
-              icon: const Icon(Icons.language),
-              onSelected: (v) {
-                settings.setLocale(Locale(v));
-              },
-              itemBuilder: (ctx) => [
-                PopupMenuItem(value: 'ar', child: Text(t.arabic)),
-                PopupMenuItem(value: 'en', child: Text(t.english)),
-              ],
-            ),
-            IconButton(
-              icon: const Icon(Icons.logout),
-              tooltip: t.logout, // أو نص يدوي "تسجيل الخروج"
-              onPressed: () => _logout(context),
-            ),
-          ],
-        ),
+                  // تبديل الثيم
+                  IconButton(
+                    tooltip: t.toggle_theme,
+                    onPressed: () => settings.toggleTheme(),
+                    icon: Icon(isDark ? Icons.light_mode : Icons.dark_mode),
+                  ),
+                  // اختيار اللغة
+                  PopupMenuButton<String>(
+                    tooltip: t.language,
+                    icon: const Icon(Icons.language),
+                    onSelected: (v) {
+                      settings.setLocale(Locale(v));
+                    },
+                    itemBuilder: (ctx) => [
+                      PopupMenuItem(value: 'ar', child: Text(t.arabic)),
+                      PopupMenuItem(value: 'en', child: Text(t.english)),
+                    ],
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.logout),
+                    tooltip: t.logout, // أو نص يدوي "تسجيل الخروج"
+                    onPressed: () => _logout(context),
+                  ),
+                ],
+              )
+            : null,
         body: child,
       ),
     );

--- a/lib/screens/forgot_password_screen.dart
+++ b/lib/screens/forgot_password_screen.dart
@@ -13,21 +13,36 @@ class ForgotPasswordScreen extends StatefulWidget {
 class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   final _form = GlobalKey<FormState>();
   final _username = TextEditingController();
+  final _email = TextEditingController();
   bool _loading = false;
+  bool _useEmail = false;
 
   @override
-  void dispose() { _username.dispose(); super.dispose(); }
+  void dispose() {
+    _username.dispose();
+    _email.dispose();
+    super.dispose();
+  }
 
   Future<void> _send() async {
     if (!_form.currentState!.validate()) return;
     setState(()=>_loading=true);
-    final r = await ApiService.forgotByUsername(_username.text.trim());
+    final r = _useEmail
+        ? await ApiService.forgotByEmail(_email.text.trim())
+        : await ApiService.forgotByUsername(_username.text.trim());
     setState(()=>_loading=false);
     if (!mounted) return;
-    if (r['ok']==true) {
+    if (r['ok']==true && r['session_id'] != null) {
       final sid = r['session_id'];
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(r['detail'] ?? AppLocalizations.of(context)!.send_code)),
+        SnackBar(
+          content: Text(
+            r['detail'] ??
+            (_useEmail
+                ? AppLocalizations.of(context)!.email_sent_success
+                : AppLocalizations.of(context)!.send_code),
+          ),
+        ),
       );
       Navigator.of(context).pushNamed(
         ResetPasswordScreen.route,
@@ -50,13 +65,49 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
         child: Form(
           key: _form,
           child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              TextFormField(
-                controller: _username,
-                decoration: InputDecoration(labelText: t.username),
-                validator: (v) => (v==null || v.trim().isEmpty) ? t.username : null,
-                onFieldSubmitted: (_) => _send(),
+              ToggleButtons(
+                isSelected: [!_useEmail, _useEmail],
+                onPressed: (index) {
+                  setState(() {
+                    _useEmail = index == 1;
+                  });
+                },
+                borderRadius: const BorderRadius.all(Radius.circular(12)),
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(t.forgot_via_username),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: Text(t.forgot_via_email),
+                  ),
+                ],
               ),
+              const SizedBox(height: 24),
+              if (!_useEmail)
+                TextFormField(
+                  controller: _username,
+                  decoration: InputDecoration(labelText: t.username),
+                  validator: (v) => (v==null || v.trim().isEmpty) ? t.username : null,
+                  onFieldSubmitted: (_) => _send(),
+                )
+              else
+                TextFormField(
+                  controller: _email,
+                  decoration: InputDecoration(labelText: t.email),
+                  keyboardType: TextInputType.emailAddress,
+                  validator: (v) {
+                    if (v == null || v.trim().isEmpty) return t.email_required;
+                    final email = v.trim();
+                    final re = RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$');
+                    if (!re.hasMatch(email)) return t.email_invalid;
+                    return null;
+                  },
+                  onFieldSubmitted: (_) => _send(),
+                ),
               const SizedBox(height: 16),
               SizedBox(
                 width: double.infinity,

--- a/lib/screens/home_guard.dart
+++ b/lib/screens/home_guard.dart
@@ -194,6 +194,63 @@ class _GuardProfilePageState extends State<GuardProfilePage> {
 
           const SizedBox(height: 12),
 
+          Consumer<AppSettings>(
+            builder: (context, settings, _) {
+              final currentLanguage =
+                  settings.locale.languageCode == 'ar' ? t.arabic : t.english;
+              return Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        t.language_settings_title,
+                        style: theme.textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        '${t.language}: $currentLanguage',
+                        style: theme.textTheme.bodySmall,
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        t.language_settings_hint,
+                        style: theme.textTheme.bodySmall,
+                      ),
+                      const SizedBox(height: 16),
+                      Wrap(
+                        spacing: 12,
+                        children: [
+                          ChoiceChip(
+                            label: Text(t.arabic),
+                            selected:
+                                settings.locale.languageCode.toLowerCase() ==
+                                    'ar',
+                            onSelected: (v) {
+                              if (v) settings.setLocale(const Locale('ar'));
+                            },
+                          ),
+                          ChoiceChip(
+                            label: Text(t.english),
+                            selected:
+                                settings.locale.languageCode.toLowerCase() ==
+                                    'en',
+                            onSelected: (v) {
+                              if (v) settings.setLocale(const Locale('en'));
+                            },
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+
+          const SizedBox(height: 12),
+
           // ===== بيانات أساسية =====
           Card(
             child: Column(
@@ -736,6 +793,7 @@ class _AttendancePageState extends State<AttendancePage> {
 
   @override
   Widget build(BuildContext context) {
+    final t = AppLocalizations.of(context)!;
     final cs = Theme.of(context).colorScheme;
     final timeStr = _time == null ? null : DateFormat.Hm().format(_time!);
 
@@ -753,6 +811,61 @@ class _AttendancePageState extends State<AttendancePage> {
             ],
           ),
 
+        Consumer<AppSettings>(
+          builder: (context, settings, _) {
+            final currentLanguage =
+                settings.locale.languageCode == 'ar' ? t.arabic : t.english;
+            return Card(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      t.language_settings_title,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '${t.language}: $currentLanguage',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      t.language_settings_hint,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 16),
+                    Wrap(
+                      spacing: 12,
+                      children: [
+                        ChoiceChip(
+                          label: Text(t.arabic),
+                          selected:
+                              settings.locale.languageCode.toLowerCase() == 'ar',
+                          onSelected: (v) {
+                            if (v) settings.setLocale(const Locale('ar'));
+                          },
+                        ),
+                        ChoiceChip(
+                          label: Text(t.english),
+                          selected:
+                              settings.locale.languageCode.toLowerCase() == 'en',
+                          onSelected: (v) {
+                            if (v) settings.setLocale(const Locale('en'));
+                          },
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+
+        const SizedBox(height: 12),
+
         Card(
           child: Padding(
             padding: const EdgeInsets.all(16),
@@ -765,7 +878,7 @@ class _AttendancePageState extends State<AttendancePage> {
                     const SizedBox(width: 16),
                     Expanded(
                       child: Text(
-                        _checkedIn ? "تم تسجيل الحضور" : "تم تسجيل الانصراف",
+                        _checkedIn ? t.checked_in : t.checked_out,
                         style: Theme.of(context).textTheme.titleLarge,
                       ),
                     ),
@@ -799,7 +912,7 @@ class _AttendancePageState extends State<AttendancePage> {
             Expanded(
               child: ElevatedButton.icon(
                 icon: const Icon(Icons.login),
-                label: const Text("تسجيل الحضور"),
+                label: Text(t.check_in),
                 onPressed: (_checkedIn || _loading || _locationId == null) ? null : () => _handleAction("check_in"),
               ),
             ),
@@ -807,7 +920,7 @@ class _AttendancePageState extends State<AttendancePage> {
             Expanded(
               child: ElevatedButton.icon(
                 icon: const Icon(Icons.logout),
-                label: const Text("تسجيل الانصراف"),
+                label: Text(t.check_out),
                 onPressed: (!_checkedIn || _loading || _locationId == null) ? null : () => _handleAction("check_out"),
               ),
             ),

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,8 +1,10 @@
 // lib/screens/splash_screen.dart
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'login_screen.dart';
+
+import '../l10n/app_localizations.dart';
 import 'home_guard.dart';
+import 'login_screen.dart';
 
 class SplashScreen extends StatefulWidget {
   static const route = '/';
@@ -11,11 +13,27 @@ class SplashScreen extends StatefulWidget {
   State<SplashScreen> createState() => _SplashScreenState();
 }
 
-class _SplashScreenState extends State<SplashScreen> {
+class _SplashScreenState extends State<SplashScreen>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _fade;
+
   @override
   void initState() {
     super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 800),
+    );
+    _fade = CurvedAnimation(parent: _controller, curve: Curves.easeInOut);
+    _controller.forward();
     _go();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
   }
 
   Future<void> _go() async {
@@ -30,6 +48,110 @@ class _SplashScreenState extends State<SplashScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(child: CircularProgressIndicator());
+    final t = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final gradientColors = isDark
+        ? const [Color(0xFF0D253F), Color(0xFF1B4B66)]
+        : const [Color(0xFFE3F2FD), Color(0xFF90CAF9)];
+
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: gradientColors,
+        ),
+      ),
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+          child: Stack(
+            children: [
+              Align(
+                alignment: Alignment.center,
+                child: FadeTransition(
+                  opacity: _fade,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Container(
+                        height: 120,
+                        width: 120,
+                        decoration: BoxDecoration(
+                          color: isDark
+                              ? Colors.black.withOpacity(0.25)
+                              : Colors.white.withOpacity(0.65),
+                          shape: BoxShape.circle,
+                          boxShadow: [
+                            BoxShadow(
+                              color: Colors.black.withOpacity(0.15),
+                              blurRadius: 20,
+                              offset: const Offset(0, 10),
+                            ),
+                          ],
+                        ),
+                        alignment: Alignment.center,
+                        child: Image.asset(
+                          'assets/images/logo.png',
+                          fit: BoxFit.contain,
+                          height: 72,
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      Text(
+                        t.app_title,
+                        style: theme.textTheme.headlineSmall?.copyWith(
+                          color: isDark ? Colors.white : Colors.blueGrey.shade900,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 12),
+                      SizedBox(
+                        width: 260,
+                        child: Text(
+                          t.splash_tagline,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: isDark
+                                ? Colors.white.withOpacity(0.85)
+                                : Colors.blueGrey.shade800,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    LinearProgressIndicator(
+                      color: isDark
+                          ? Colors.lightBlueAccent.shade100
+                          : theme.colorScheme.primary,
+                      backgroundColor:
+                          Colors.white.withOpacity(isDark ? 0.1 : 0.4),
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      t.splash_loading,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color:
+                            isDark ? Colors.white70 : Colors.blueGrey.shade700,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/services/api.dart
+++ b/lib/services/api.dart
@@ -298,6 +298,34 @@ class ApiService {
   }
 
   // ---------------------------------------------
+  // نسيت كلمة المرور — بالبريد الإلكتروني
+  // POST /auth/password/forgot/email/
+  // body: {email}
+  // ---------------------------------------------
+  static Future<Map<String, dynamic>> forgotByEmail(String email) async {
+    try {
+      final res = await _client.post(
+        _u('/auth/password/forgot/email/'),
+        headers: _jsonHeaders(),
+        body: jsonEncode({'email': email}),
+      ).timeout(const Duration(seconds: 20));
+
+      final body = _decode(res);
+      if (res.statusCode == 200 && body is Map<String, dynamic>) {
+        return {'ok': true, 'session_id': body['session_id'], 'detail': body['detail']};
+      }
+      return {
+        'ok': false,
+        'message': (body is Map && body['detail'] != null)
+            ? body['detail'].toString()
+            : 'تعذر إرسال البريد الإلكتروني',
+      };
+    } catch (e) {
+      return {'ok': false, 'message': 'Network error: $e'};
+    }
+  }
+
+  // ---------------------------------------------
   // إعادة تعيين كلمة المرور (session_id + code + new_password)
   // POST /auth/password/reset/username/
   // ---------------------------------------------


### PR DESCRIPTION
## Summary
- redesign the splash screen with branding, animation, and status messaging
- add an email option for password recovery and hook it to a dedicated API call
- surface language selection controls on the profile and attendance tabs for quicker access

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc315490a8833392d616617c95e5fa